### PR TITLE
chore(Pre pass): table refactor to tree

### DIFF
--- a/src/Command/Components/PassPlan/PassList/PassList.css
+++ b/src/Command/Components/PassPlan/PassList/PassList.css
@@ -1,17 +1,3 @@
-.pass_header-wrapper {
-  display: flex;
-  background: var(--color-background-surface-header);
-  padding-block: var(--spacing-2);
-}
-
-.pass_header-step {
-  padding-inline-start: var(--spacing-3);
-}
-
-.pass_header-instruction {
-  padding-inline-start: var(--spacing-20);
-}
-
 rux-tree.pass_body-wrapper rux-tree-node::part(text) {
   padding-inline-start: var(--spacing-8);
   width: 100%;

--- a/src/Command/Components/PassPlan/PassList/PassList.tsx
+++ b/src/Command/Components/PassPlan/PassList/PassList.tsx
@@ -6,21 +6,15 @@ import ExecutableListItem from "./ExecutableListItem/ExecutableListItem";
 
 const PassList = () => {
   return (
-    <>
-      <div className="pass_header-wrapper">
-        <div className="pass_header-step">Step</div>
-        <div className="pass_header-instruction">Instruction</div>
-      </div>
-      <RuxTree className="pass_body-wrapper">
-        <MnemonicListItem stepNumber={1} slotNode={false} />
-        <MnemonicListItem stepNumber={2} slotNode={false} />
-        <MnemonicListItem stepNumber={3} slotNode={false} />
-        <SelectMenuListItem stepNumber={4} />
-        <ExecutableListItem stepNumber={5} />
-        <MnemonicListItem stepNumber={6} slotNode={false} />
-        <MnemonicListItem stepNumber={7} slotNode={false} />
-      </RuxTree>
-    </>
+    <RuxTree className="pass_body-wrapper">
+      <MnemonicListItem stepNumber={1} slotNode={false} />
+      <MnemonicListItem stepNumber={2} slotNode={false} />
+      <MnemonicListItem stepNumber={3} slotNode={false} />
+      <SelectMenuListItem stepNumber={4} />
+      <ExecutableListItem stepNumber={5} />
+      <MnemonicListItem stepNumber={6} slotNode={false} />
+      <MnemonicListItem stepNumber={7} slotNode={false} />
+    </RuxTree>
   );
 };
 

--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -70,6 +70,20 @@ li {
   box-shadow: 0px 3px 3px 0px rgb(0 0 0 / 40%);
 }
 
+.pass_header-wrapper {
+  display: flex;
+  background: var(--color-background-surface-header);
+  padding-block: var(--spacing-2);
+}
+
+.pass_header-step {
+  padding-inline-start: var(--spacing-3);
+}
+
+.pass_header-instruction {
+  padding-inline-start: var(--spacing-20);
+}
+
 .rux-tree-header span:nth-of-type(1) {
   margin-right: 4.5rem;
 }

--- a/src/Command/Components/PassPlan/PassPlan.tsx
+++ b/src/Command/Components/PassPlan/PassPlan.tsx
@@ -25,6 +25,10 @@ const PassPlan = () => {
       </div>
       <div>
         <div className={`banner ${pass}`}>{pass}</div>
+        <div className="pass_header-wrapper">
+        <div className="pass_header-step">Step</div>
+        <div className="pass_header-instruction">Instruction</div>
+      </div>
         {pass === "Pre-Pass" ? <PrePassList setPass={setPass} /> : <PassList />}
       </div>
       <div slot="footer">

--- a/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
+++ b/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
@@ -1,13 +1,8 @@
 import {
   RuxCheckbox,
   RuxProgress,
-  RuxTable,
-  RuxTableBody,
-  RuxTableCell,
-  RuxTableHeader,
-  RuxTableHeaderCell,
-  RuxTableHeaderRow,
-  RuxTableRow,
+  RuxTree,
+  RuxTreeNode,
 } from "@astrouxds/react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import "./PrePassList.css";
@@ -44,7 +39,7 @@ const PrePassList = ({ setPass }: PropTypes) => {
 
     // if the current list item is the length of the state function array, set the pass from 'pre-pass' into 'pass'
     if (currentListItem === stateFunctionArray.length) {
-      setPass("Pass");
+      //setPass("Pass");
       return;
     }
 
@@ -79,90 +74,80 @@ const PrePassList = ({ setPass }: PropTypes) => {
   }, [currentListItem, setPass]);
 
   return (
-    <>
-      <RuxTable className="pre-pass-list-table">
-        <RuxTableHeader>
-          <RuxTableHeaderRow>
-            <RuxTableHeaderCell>Step</RuxTableHeaderCell>
-            <RuxTableHeaderCell>Instruction</RuxTableHeaderCell>
-          </RuxTableHeaderRow>
-        </RuxTableHeader>
-        <RuxTableBody>
-          <RuxTableRow>
-            <RuxTableCell>
-              <div className="pre-pass_cell-item-number">1</div>
-            </RuxTableCell>
-            <RuxTableCell>
-              <div className="pre-pass_cell-wrapper-content">
-                <RuxCheckbox className="pre-pass_checkbox" />
-                AIM = {aimState}
-                <RuxProgress className="pre-pass_progress" hideLabel={true} />
-              </div>
-            </RuxTableCell>
-          </RuxTableRow>
-          <RuxTableRow>
-            <RuxTableCell>
-              <div className="pre-pass_cell-item-number">2</div>
-            </RuxTableCell>
-            <RuxTableCell>
-              <div className="pre-pass_cell-wrapper-content">
-                <RuxCheckbox className="pre-pass_checkbox" />
-                SARM = {sarmState}
-                <RuxProgress className="pre-pass_progress" hideLabel={true} />
-              </div>
-            </RuxTableCell>
-          </RuxTableRow>
-          <RuxTableRow>
-            <RuxTableCell>
-              <div className="pre-pass_cell-item-number">3</div>
-            </RuxTableCell>
-            <RuxTableCell>
-              <div className="pre-pass_cell-wrapper-content">
-                <RuxCheckbox className="pre-pass_checkbox" />
-                LOCK = {lockState}
-                <RuxProgress className="pre-pass_progress" hideLabel={true} />
-              </div>
-            </RuxTableCell>
-          </RuxTableRow>
-          <RuxTableRow>
-            <RuxTableCell>
-              <div className="pre-pass_cell-item-number">4</div>
-            </RuxTableCell>
-            <RuxTableCell>
-              <div className="pre-pass_cell-wrapper-content">
-                <RuxCheckbox className="pre-pass_checkbox" />
-                AOS = {aosState}
-                <RuxProgress className="pre-pass_progress" hideLabel={true} />
-              </div>
-            </RuxTableCell>
-          </RuxTableRow>
-          <RuxTableRow>
-            <RuxTableCell>
-              <div className="pre-pass_cell-item-number">5</div>
-            </RuxTableCell>
-            <RuxTableCell>
-              <div className="pre-pass_cell-wrapper-content">
-                <RuxCheckbox className="pre-pass_checkbox" />
-                VCC = {vccState}
-                <RuxProgress className="pre-pass_progress" hideLabel={true} />
-              </div>
-            </RuxTableCell>
-          </RuxTableRow>
-          <RuxTableRow>
-            <RuxTableCell>
-              <div className="pre-pass_cell-item-number">6</div>
-            </RuxTableCell>
-            <RuxTableCell>
-              <div className="pre-pass_cell-wrapper-content">
-                <RuxCheckbox className="pre-pass_checkbox" />
-                PASS PLAN = {passPlanState}
-                <RuxProgress className="pre-pass_progress" hideLabel={true} />
-              </div>
-            </RuxTableCell>
-          </RuxTableRow>
-        </RuxTableBody>
-      </RuxTable>
-    </>
+    <RuxTree>
+      <RuxTreeNode>
+        <div slot="prefix">1</div>
+        <div className="pre-pass_cell-wrapper-content">
+          <RuxCheckbox className="pre-pass_checkbox" />
+          AIM = {aimState}
+        </div>
+        <RuxProgress
+          slot="suffix"
+          className="pre-pass_progress"
+          hideLabel={true}
+        />
+      </RuxTreeNode>
+      <RuxTreeNode>
+        <div slot="prefix">2</div>
+        <div className="pre-pass_cell-wrapper-content">
+          <RuxCheckbox className="pre-pass_checkbox" />
+          SARM = {sarmState}
+        </div>
+        <RuxProgress
+          slot="suffix"
+          className="pre-pass_progress"
+          hideLabel={true}
+        />
+      </RuxTreeNode>
+      <RuxTreeNode>
+        <div slot="prefix">3</div>
+        <div className="pre-pass_cell-wrapper-content">
+          <RuxCheckbox className="pre-pass_checkbox" />
+          LOCK = {lockState}
+        </div>
+        <RuxProgress
+          slot="suffix"
+          className="pre-pass_progress"
+          hideLabel={true}
+        />
+      </RuxTreeNode>
+      <RuxTreeNode>
+        <div slot="prefix">4</div>
+        <div className="pre-pass_cell-wrapper-content">
+          <RuxCheckbox className="pre-pass_checkbox" />
+          AOS = {aosState}
+        </div>
+        <RuxProgress
+          slot="suffix"
+          className="pre-pass_progress"
+          hideLabel={true}
+        />
+      </RuxTreeNode>
+      <RuxTreeNode>
+        <div slot="prefix">5</div>
+        <div className="pre-pass_cell-wrapper-content">
+          <RuxCheckbox className="pre-pass_checkbox" />
+          VCC = {vccState}
+        </div>
+        <RuxProgress
+          slot="suffix"
+          className="pre-pass_progress"
+          hideLabel={true}
+        />
+      </RuxTreeNode>
+      <RuxTreeNode>
+        <div slot="prefix">6</div>
+        <div className="pre-pass_cell-wrapper-content">
+          <RuxCheckbox className="pre-pass_checkbox" />
+          PASS PLAN = {passPlanState}
+        </div>
+        <RuxProgress
+          slot="suffix"
+          className="pre-pass_progress"
+          hideLabel={true}
+        />
+      </RuxTreeNode>
+    </RuxTree>
   );
 };
 

--- a/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
+++ b/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
@@ -39,7 +39,7 @@ const PrePassList = ({ setPass }: PropTypes) => {
 
     // if the current list item is the length of the state function array, set the pass from 'pre-pass' into 'pass'
     if (currentListItem === stateFunctionArray.length) {
-      //setPass("Pass");
+      setPass("Pass");
       return;
     }
 


### PR DESCRIPTION
This PR changes the Pre Pass component from a `rux-table` to a `rux-tree` to better match the styling of the pass component.