### PR TITLE
Prevent chart data from changing on re-render

### DIFF
--- a/src/Command/Components/Watcher/MnemonicPopUp.tsx
+++ b/src/Command/Components/Watcher/MnemonicPopUp.tsx
@@ -11,6 +11,7 @@ import { getRandomInt } from "utils";
 import { useAppContext, ContextType } from "provider/useAppContext";
 import type { Subsystem } from "@astrouxds/mock-data";
 import "./MnemonicPopUp.css";
+import { useMemo } from "react";
 
 type PropTypes = {
   triggerValue: string | number;
@@ -26,15 +27,18 @@ const MnemonicPopUp = ({ triggerValue, data, isPassPlan }: PropTypes) => {
     selectSubsystemsFromMnemonic,
   }: ContextType = useAppContext();
 
-  const menmonicData = [
-    getRandomInt(110),
-    getRandomInt(110),
-    getRandomInt(110),
-    data.currentValue,
-    getRandomInt(110),
-    getRandomInt(110),
-    getRandomInt(110),
-  ];
+  const menmonicData = useMemo(
+    () => [
+      getRandomInt(110),
+      getRandomInt(110),
+      getRandomInt(110),
+      data.currentValue,
+      getRandomInt(110),
+      getRandomInt(110),
+      getRandomInt(110),
+    ],
+    [data.currentValue]
+  );
 
   const handleSubsystemClick = (subsystem: Subsystem) => {
     toggleInvestigate();


### PR DESCRIPTION
Prevent the chart data in the pop-up from changing on re-render