### PR TITLE
feat(pass plan): pre-pass complete component

### DIFF
--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -118,3 +118,15 @@ rux-tree.pass_body-wrapper rux-tree-node::part(text) {
   width: 100%;
   margin-right: var(--spacing-2);
 }
+
+.pass_pre-pass-complete-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+}
+
+rux-indeterminate-progress {
+  padding-block-end: var(--spacing-3);
+}

--- a/src/Command/Components/PassPlan/PassPlan.tsx
+++ b/src/Command/Components/PassPlan/PassPlan.tsx
@@ -35,7 +35,6 @@ const PassPlan = () => {
             clearInterval(interval);
             setPass("Pass");
           }
-          console.log(countdown);
           return prevValue - 1;
         });
       }, 1000);

--- a/src/Command/Components/PassPlan/PassPlan.tsx
+++ b/src/Command/Components/PassPlan/PassPlan.tsx
@@ -2,17 +2,20 @@ import { RuxContainer, RuxOption, RuxSelect } from "@astrouxds/react";
 import "./PassPlan.css";
 import commands from "../../../utils/commands.json";
 import SearchCommands from "./SearchCommands/SearchCommands";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PrePassList from "./PrePassList/PrePassList";
 import PassList from "./PassList/PassList";
 import { useAppContext, ContextType } from "provider/useAppContext";
+import PrePassComplete from "./PrePassComplete/PrePassComplete";
 
 const PassPlan = () => {
   const [command, setCommand] = useState({});
   const [pass, setPass] = useState("Pre-Pass");
   const [commandList, setCommandList] = useState<string[]>([]);
+  const [countdown, setCountdown] = useState<number>(4);
   const { contact }: ContextType = useAppContext();
   const passPlanMnemonics = contact.mnemonics.slice(0, 100);
+  let countdownFormat: string = `00:00:0${countdown}`;
 
   const addToPassQueue = (commandListItem: {
     commandId: number;
@@ -22,6 +25,28 @@ const PassPlan = () => {
     if (!commandListItem) return;
     setCommandList([...commandList, commandListItem.commandString]);
   };
+
+  useEffect(() => {
+    let interval: any;
+    if (pass === "Pre-Pass-Complete" && countdown >= 1) {
+      interval = setInterval(() => {
+        setCountdown((prevValue) => {
+          if (prevValue <= 0) {
+            clearInterval(interval);
+            setPass("Pass");
+          }
+          console.log(countdown);
+          return prevValue - 1;
+        });
+      }, 1000);
+    } else {
+      clearInterval(interval);
+    }
+
+    return () => clearInterval(interval);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pass]);
   return (
     <RuxContainer className="pass-plan">
       <div slot="header" className="header">
@@ -31,13 +56,19 @@ const PassPlan = () => {
           <RuxOption label="Automatic" value="" />
         </RuxSelect>
       </div>
-      <div className={`banner ${pass}`}>{pass}</div>
+      <div className={`banner ${pass}`}>
+        {pass === "Pre-Pass-Complete"
+          ? `${pass}. Pass starts in ${countdownFormat}`
+          : pass}
+      </div>
       <div className="pass_header-wrapper">
         <div className="pass_header-step">Step</div>
         <div className="pass_header-instruction">Instruction</div>
       </div>
       {pass === "Pre-Pass" ? (
         <PrePassList setPass={setPass} />
+      ) : pass === "Pre-Pass-Complete" ? (
+        <PrePassComplete setPass={setPass} />
       ) : (
         <PassList commandList={commandList} mnemonics={passPlanMnemonics} />
       )}

--- a/src/Command/Components/PassPlan/PrePassComplete/PrePassComplete.tsx
+++ b/src/Command/Components/PassPlan/PrePassComplete/PrePassComplete.tsx
@@ -1,0 +1,25 @@
+import {
+    RuxIndeterminateProgress,
+    RuxTree,
+    RuxTreeNode,
+  } from "@astrouxds/react";
+  import { Dispatch, SetStateAction } from "react";
+  import "./PrePassList.css";
+  
+  type PropTypes = {
+    setPass: Dispatch<SetStateAction<string>>;
+  };
+  
+  const PrePassComplete = ({ setPass }: PropTypes) => {
+  
+    return (
+      <RuxTree className="pass_body-wrapper">
+        <RuxTreeNode>
+            <RuxIndeterminateProgress />
+        </RuxTreeNode>
+      </RuxTree>
+    );
+  };
+  
+  export default PrePassComplete;
+  

--- a/src/Command/Components/PassPlan/PrePassComplete/PrePassComplete.tsx
+++ b/src/Command/Components/PassPlan/PrePassComplete/PrePassComplete.tsx
@@ -1,25 +1,23 @@
 import {
-    RuxIndeterminateProgress,
-    RuxTree,
-    RuxTreeNode,
-  } from "@astrouxds/react";
-  import { Dispatch, SetStateAction } from "react";
-  import "./PrePassList.css";
-  
-  type PropTypes = {
-    setPass: Dispatch<SetStateAction<string>>;
-  };
-  
-  const PrePassComplete = ({ setPass }: PropTypes) => {
-  
-    return (
-      <RuxTree className="pass_body-wrapper">
-        <RuxTreeNode>
-            <RuxIndeterminateProgress />
-        </RuxTreeNode>
-      </RuxTree>
-    );
-  };
-  
-  export default PrePassComplete;
-  
+  RuxIndeterminateProgress,
+  RuxTree,
+  RuxTreeNode,
+} from "@astrouxds/react";
+import { Dispatch, SetStateAction } from "react";
+import "./PrePassList.css";
+
+type PropTypes = {
+  setPass: Dispatch<SetStateAction<string>>;
+};
+
+const PrePassComplete = ({ setPass }: PropTypes) => {
+  return (
+    <RuxTree className="pass_body-wrapper">
+      <RuxTreeNode>
+        <RuxIndeterminateProgress />
+      </RuxTreeNode>
+    </RuxTree>
+  );
+};
+
+export default PrePassComplete;

--- a/src/Command/Components/PassPlan/PrePassComplete/PrePassComplete.tsx
+++ b/src/Command/Components/PassPlan/PrePassComplete/PrePassComplete.tsx
@@ -1,10 +1,5 @@
-import {
-  RuxIndeterminateProgress,
-  RuxTree,
-  RuxTreeNode,
-} from "@astrouxds/react";
+import { RuxIndeterminateProgress } from "@astrouxds/react";
 import { Dispatch, SetStateAction } from "react";
-import "./PrePassList.css";
 
 type PropTypes = {
   setPass: Dispatch<SetStateAction<string>>;
@@ -12,11 +7,12 @@ type PropTypes = {
 
 const PrePassComplete = ({ setPass }: PropTypes) => {
   return (
-    <RuxTree className="pass_body-wrapper">
-      <RuxTreeNode>
-        <RuxIndeterminateProgress />
-      </RuxTreeNode>
-    </RuxTree>
+    <div className="pass_pre-pass-complete-wrapper">
+      <RuxIndeterminateProgress />
+      <div>
+        <i>Loading Pass Plan...</i>
+      </div>
+    </div>
   );
 };
 

--- a/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
+++ b/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
@@ -39,7 +39,7 @@ const PrePassList = ({ setPass }: PropTypes) => {
 
     // if the current list item is the length of the state function array, set the pass from 'pre-pass' into 'pass'
     if (currentListItem === stateFunctionArray.length) {
-      setPass("Pass");
+      setPass("Pre-Pass-Complete");
       return;
     }
 


### PR DESCRIPTION
This PR adds in a component to handle the state between pre-pass and pass where a certain amount of time will pass before swapping into the pass state. I have the countdown set to 4, if we want it to be in the double digits like in the wireframes the string that it is wrapped in will need a tiny bit of work.