### PR TITLE
downgrade cytoscape.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/react-cytoscapejs": "^1.2.2",
-        "cytoscape": "^3.26.0",
+        "cytoscape": "^3.2.19",
         "cytoscape-dagre": "^2.5.0",
         "react": "^18.2.0",
         "react-apexcharts": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/react-cytoscapejs": "^1.2.2",
-    "cytoscape": "^3.26.0",
+    "cytoscape": "3.2.19",
     "cytoscape-dagre": "^2.5.0",
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.1",


### PR DESCRIPTION
Cytoscape was not running in Firefox and causing the app to crash. It turns out that this is because react-cytoscape has not been updated in a year and newer versions of cytoscapejs are not fully compatible (as far as I can tell). I downgraded cytoscapejs since I only installed it so that I could use the .use function and get the dagre theme.

I branched this off my previous fixes so I'm thinking to merge it into those