### PR TITLE
chore(pass plan): design audit changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrouxds/mock-data": "^0.6.4",
-        "@astrouxds/react": "^7.15.2",
-        "@astrouxds/tokens": "^1.9.0",
+        "@astrouxds/react": "^7.16.0",
+        "@astrouxds/tokens": "^1.11.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@astrouxds/astro-web-components": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.15.2.tgz",
-      "integrity": "sha512-lDj5imItYnQK903z3LMVU7H+cvUJu63eSeU2i+5GmjmcuynhIf+rWe2d9/daWOvnNHadiJhuLlZLBmn+T/U3fQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.16.0.tgz",
+      "integrity": "sha512-MEnYh9bpeRTdRf2oa8UFBgEsNkQgPTtvmxfNv46TBdpzS6F0oW83N9HUOqnNoUXGktl+O1WpQw2If+sQ4Jcl1A==",
       "dependencies": {
         "@floating-ui/dom": "~1.0.6",
         "@stencil/core": "~3.4.1",
@@ -88,11 +88,11 @@
       }
     },
     "node_modules/@astrouxds/react": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@astrouxds/react/-/react-7.15.2.tgz",
-      "integrity": "sha512-zUIgvopBbwguhzBdaqiewHC4o9Tw9pSv5Prs6lBTDfdII52LgCHzUKCIfYN0Xwh94XgaLXoitJhGpDmvNVczlA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/react/-/react-7.16.0.tgz",
+      "integrity": "sha512-7eqIUY4F4dokha/moJMVPjYJBgw5ShL6UoZuJrezyl13z+xsHIBQZ+AkVM01Ryl1mp9RGcjQK6YgO7gomjuPBg==",
       "dependencies": {
-        "@astrouxds/astro-web-components": "^7.15.2"
+        "@astrouxds/astro-web-components": "^7.16.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@astrouxds/tokens": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.9.0.tgz",
-      "integrity": "sha512-KdwwUK9RWSyvHZCukVO2nribo/SyPmzyNKZiZgNe7qR/S8xZctCnQsm2aAaD8ftfcFGyVdXnJiQRZfks6DlkJw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.11.0.tgz",
+      "integrity": "sha512-JBZHAdrw3IZGqa2siasyyv5DUVUg/9nzw9EbRfXkDCCqFRyv1/ea9qRDki8h9sNobwDfwvRIzCgAQxDb1DaPgg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.5",
@@ -17872,9 +17872,9 @@
       }
     },
     "@astrouxds/astro-web-components": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.15.2.tgz",
-      "integrity": "sha512-lDj5imItYnQK903z3LMVU7H+cvUJu63eSeU2i+5GmjmcuynhIf+rWe2d9/daWOvnNHadiJhuLlZLBmn+T/U3fQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/astro-web-components/-/astro-web-components-7.16.0.tgz",
+      "integrity": "sha512-MEnYh9bpeRTdRf2oa8UFBgEsNkQgPTtvmxfNv46TBdpzS6F0oW83N9HUOqnNoUXGktl+O1WpQw2If+sQ4Jcl1A==",
       "requires": {
         "@floating-ui/dom": "~1.0.6",
         "@stencil/core": "~3.4.1",
@@ -17892,17 +17892,17 @@
       }
     },
     "@astrouxds/react": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@astrouxds/react/-/react-7.15.2.tgz",
-      "integrity": "sha512-zUIgvopBbwguhzBdaqiewHC4o9Tw9pSv5Prs6lBTDfdII52LgCHzUKCIfYN0Xwh94XgaLXoitJhGpDmvNVczlA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/react/-/react-7.16.0.tgz",
+      "integrity": "sha512-7eqIUY4F4dokha/moJMVPjYJBgw5ShL6UoZuJrezyl13z+xsHIBQZ+AkVM01Ryl1mp9RGcjQK6YgO7gomjuPBg==",
       "requires": {
-        "@astrouxds/astro-web-components": "^7.15.2"
+        "@astrouxds/astro-web-components": "^7.16.0"
       }
     },
     "@astrouxds/tokens": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.9.0.tgz",
-      "integrity": "sha512-KdwwUK9RWSyvHZCukVO2nribo/SyPmzyNKZiZgNe7qR/S8xZctCnQsm2aAaD8ftfcFGyVdXnJiQRZfks6DlkJw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.11.0.tgz",
+      "integrity": "sha512-JBZHAdrw3IZGqa2siasyyv5DUVUg/9nzw9EbRfXkDCCqFRyv1/ea9qRDki8h9sNobwDfwvRIzCgAQxDb1DaPgg=="
     },
     "@babel/code-frame": {
       "version": "7.22.5",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@astrouxds/mock-data": "^0.6.4",
-    "@astrouxds/react": "^7.15.2",
-    "@astrouxds/tokens": "^1.9.0",
+    "@astrouxds/react": "^7.16.0",
+    "@astrouxds/tokens": "^1.11.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.css
+++ b/src/App.css
@@ -78,6 +78,12 @@ rux-status::part(status) {
   margin-inline: auto;
 }
 
+/* GLOBAL TREE STYLES */
+
+rux-tree-node::part(node):focus {
+  outline-offset: -1px;
+}
+
 /* INVESTIGATE OVERLAY STYLES */
 
 .investigate__overlay {

--- a/src/Command/Components/PassPlan/PassList/MnemonicListItem/MnemonicPopUp.css
+++ b/src/Command/Components/PassPlan/PassList/MnemonicListItem/MnemonicPopUp.css
@@ -38,8 +38,10 @@
 
 .mnemonic-pop-up rux-card div {
   display: flex;
-  justify-content: space-between;
-  gap: var(--spacing-8);
+}
+
+.mnemonic-pop-up rux-card div .subsystem-button {
+  margin-left: var(--spacing-1);
 }
 
 .mnemonic-pop-up rux-checkbox::part(label) {

--- a/src/Command/Components/PassPlan/PassList/MnemonicListItem/MnemonicPopUp.tsx
+++ b/src/Command/Components/PassPlan/PassList/MnemonicListItem/MnemonicPopUp.tsx
@@ -48,7 +48,7 @@ const MnemonicPopUp = ({ triggerValue, data }: PropTypes) => {
 
   return (
     <RuxPopUp
-      placement="right-end"
+      placement="right"
       strategy="fixed"
       className="mnemonic-pop-up"
     >

--- a/src/Command/Components/PassPlan/PassList/MnemonicListItem/MnemonicPopUp.tsx
+++ b/src/Command/Components/PassPlan/PassList/MnemonicListItem/MnemonicPopUp.tsx
@@ -47,23 +47,20 @@ const MnemonicPopUp = ({ triggerValue, data }: PropTypes) => {
   };
 
   return (
-    <RuxPopUp
-      placement="right"
-      strategy="fixed"
-      className="mnemonic-pop-up"
-    >
+    <RuxPopUp placement="right" strategy="fixed" className="mnemonic-pop-up">
       <RuxCard>
         <span slot="header">{data.mnemonicId}</span>
         {<LineChart chartData={menmonicData} />}
         <div>
-          <span>Value</span>
+          <span>Value:</span>
           <span>
             {data.currentValue} {data.unit}
           </span>
         </div>
         <div>
-          <span className="subsystem">Subsystem</span>
+          <span className="subsystem">Subsystem:</span>
           <RuxButton
+            className="subsystem-button"
             size="small"
             borderless
             onClick={() => handleSubsystemPassPlanClick()}

--- a/src/Command/Components/PassPlan/PassList/PassList.css
+++ b/src/Command/Components/PassPlan/PassList/PassList.css
@@ -37,10 +37,6 @@
   padding-inline-end: var(--spacing-2);
 }
 
-.pass-plan_executable-wrapper rux-icon {
-  color: var(--color-text-primary);
-}
-
 .pass-plan_progress-time {
   display: flex;
   align-items: center;

--- a/src/Command/Components/PassPlan/PassList/SelectMenuListItem/SelectMenuListItem.tsx
+++ b/src/Command/Components/PassPlan/PassList/SelectMenuListItem/SelectMenuListItem.tsx
@@ -20,10 +20,10 @@ const SelectMenuListItem = ({ stepNumber }: PropTypes) => {
           value={xyz}
           onRuxchange={(e) => setXyz(e.target.value as string)}
         >
-          <RuxOption label="yes" value="yes">
+          <RuxOption label="Yes" value="yes">
             Yes
           </RuxOption>
-          <RuxOption label="no" value="no">
+          <RuxOption label="No" value="no">
             No
           </RuxOption>
         </RuxSelect>
@@ -32,10 +32,10 @@ const SelectMenuListItem = ({ stepNumber }: PropTypes) => {
           value={receiveTelemetry}
           onRuxchange={(e) => setReceiveTelemetry(e.target.value as string)}
         >
-          <RuxOption label="yes" value="yes">
+          <RuxOption label="Yes" value="yes">
             Yes
           </RuxOption>
-          <RuxOption label="no" value="no">
+          <RuxOption label="No" value="no">
             No
           </RuxOption>
         </RuxSelect>

--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -80,15 +80,15 @@ rux-tree.pass-plan_tree-wrapper rux-tree-node::part(text) {
 
 /* Styles to fix row padding */
 rux-tree.pass-plan_tree-wrapper rux-tree-node[aria-level="2"] {
-  padding-block-start: var(--spacing-050);
+  padding-block-start: var(--spacing-1);
 }
 
 rux-tree.pass-plan_tree-wrapper rux-tree-node:first-child {
-  padding-block-start: var(--spacing-050);
+  padding-block-start: var(--spacing-1);
 }
 
 rux-tree.pass-plan_tree-wrapper rux-tree-node:last-child:not([aria-level="2"]) {
-  padding-block-end: var(--spacing-050);
+  padding-block-end: var(--spacing-1);
 }
 
 .pass-plan_tree-content-wrapper {

--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -78,6 +78,7 @@ rux-tree.pass-plan_tree-wrapper rux-tree-node::part(text) {
   padding-block: var(--spacing-1);
 }
 
+/* Styles to fix row padding */
 rux-tree.pass-plan_tree-wrapper rux-tree-node[aria-level="2"] {
   padding-block-start: var(--spacing-050);
 }

--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -75,6 +75,7 @@ rux-tree.pass-plan_tree-wrapper {
 rux-tree.pass-plan_tree-wrapper rux-tree-node::part(text) {
   padding-inline-start: var(--spacing-8);
   width: 100%;
+  padding-block: var(--spacing-1);
 }
 
 .pass-plan_tree-content-wrapper {

--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -78,6 +78,18 @@ rux-tree.pass-plan_tree-wrapper rux-tree-node::part(text) {
   padding-block: var(--spacing-1);
 }
 
+rux-tree.pass-plan_tree-wrapper rux-tree-node[aria-level="2"] {
+  padding-block-start: var(--spacing-050);
+}
+
+rux-tree.pass-plan_tree-wrapper rux-tree-node:first-child {
+  padding-block-start: var(--spacing-050);
+}
+
+rux-tree.pass-plan_tree-wrapper rux-tree-node:last-child:not([aria-level="2"]) {
+  padding-block-end: var(--spacing-050);
+}
+
 .pass-plan_tree-content-wrapper {
   display: flex;
   align-items: center;

--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -46,7 +46,7 @@ rux-select.pass-plan_header-select::part(label) {
 }
 
 .pass-plan_header-instruction {
-  padding-inline-start: var(--spacing-20);
+  padding-inline-start: var(--spacing-16);
 }
 
 /* Content/Body Styles */
@@ -73,7 +73,7 @@ rux-tree.pass-plan_tree-wrapper {
 }
 
 rux-tree.pass-plan_tree-wrapper rux-tree-node::part(text) {
-  padding-inline-start: var(--spacing-8);
+  padding-inline-start: var(--spacing-6);
   width: 100%;
   padding-block: var(--spacing-1);
 }
@@ -90,6 +90,10 @@ rux-tree.pass-plan_tree-wrapper rux-tree-node::part(text) {
 
 .pass-plan_tree-content-wrapper > rux-progress {
   margin-inline-start: auto;
+}
+
+rux-tree-node[aria-level="2"]::part(node) {
+  padding-left: var(--spacing-20);
 }
 
 /* List Item Styles */


### PR DESCRIPTION
This PR encompasses changes requested from design from their [audit.](https://rocketcom.atlassian.net/wiki/spaces/AS11/pages/2972581954/TT+C+Command+Investigate#Pass-Plan-%2F-Center-Panel) It includes all of the fixes from the following tickets:

[TICKET 1](https://rocketcom.atlassian.net/browse/DEMO-231)
[TICKET 2](https://rocketcom.atlassian.net/browse/DEMO-232)
[TICKET 3](https://rocketcom.atlassian.net/browse/DEMO-233)

I went ahead and made all of the other changes that I saw in the audit for PASS PLAN that were not included in these tickets. _except_ for one item which stipulated that the focus for a tree item was cut off on the left and right. This will not be possible to fix due to adding padding in this area will make the tree item look different in a way that deviates from the wireframes. I think we should forgo this fix in lieu of having the app look correct. The focus state is still visible and usable.

**This PR also includes and update to the latest version of all Astro NPM packages**