### PR TITLE
feat(watcher): adding in confirm dialog for when remove from watcher is selected from the watcher table

### DIFF
--- a/src/Command/Components/Watcher/WatcherListItem.tsx
+++ b/src/Command/Components/Watcher/WatcherListItem.tsx
@@ -7,11 +7,13 @@ import {
   RuxMenu,
   RuxMenuItem,
   RuxTooltip,
+  RuxDialog,
 } from "@astrouxds/react";
 import type { Mnemonic, Status } from "@astrouxds/mock-data";
 import { useTTCGRMActions } from "@astrouxds/mock-data";
 
 import { useAppContext, ContextType } from "provider/useAppContext";
+import { RuxDialogCustomEvent } from "@astrouxds/astro-web-components";
 
 type PropTypes = {
   rowData: Mnemonic;
@@ -29,10 +31,8 @@ const WatcherListItem = ({ rowData, chartDataSlope, index }: PropTypes) => {
 
   const handleRuxMenuSelected = (e: any, mnemonic: Mnemonic) => {
     if (e.detail.value === "remove") {
-      modifyMnemonic({
-        ...rowData,
-        watched: false,
-      });
+      const dialog: HTMLRuxDialogElement = document.querySelector(`rux-dialog.watcher-dialog-${rowData.mnemonicId}`)!;
+      dialog.open = true;      
     }
     if (e.detail.value === "investigate") {
       selectMnemonic(mnemonic);
@@ -42,9 +42,20 @@ const WatcherListItem = ({ rowData, chartDataSlope, index }: PropTypes) => {
     return;
   };
 
+  const handleDialogConfirm = (e: RuxDialogCustomEvent<boolean | null>) => {
+    if (e.detail === true) {
+      modifyMnemonic({
+        ...rowData,
+        watched: false,
+      });
+    }
+  }
+
   const tooltipMessage = `${rowData.subsystem}/ ${rowData.measurement} - ${rowData.mnemonicId} `;
 
   return (
+    <>
+    <RuxDialog className={`watcher-dialog-${rowData.mnemonicId}`} confirmText="Yes, Delete" denyText="Cancel" message="Please confirm you wish to delete the selected item from the Watcher?" onRuxdialogclosed={(e) => handleDialogConfirm(e)} />
     <RuxTableRow key={rowData.mnemonicId} data-index={index}>
       <RuxTableCell>
         <RuxStatus status={rowData.status as Status} />
@@ -76,6 +87,7 @@ const WatcherListItem = ({ rowData, chartDataSlope, index }: PropTypes) => {
         </RuxPopUp>
       </RuxTableCell>
     </RuxTableRow>
+    </>
   );
 };
 


### PR DESCRIPTION
This PR adds in a confirm dialog when the 'Remove from Watcher' selection is chosen from the actions button in the watcher table. The code changes include triggering the popup from the `onRuxselected` event and then moving the actual mnemonic watcher modification into a new function run on dialog's `onRuxdialogclosed` when the passed in boolean is set to true (indicating the user has clicked on the confirm button.

**Issues and Limitations**
I did not add this same functionality to the watcher add/remove on checkbox select/deselect, which occurs in two places in the app, as this seemed like an odd pattern, and the wireframes only mentioned having this popup from this specific action menu. We should discuss.