### PR TITLE
feat(pre-pass): checkboxes -> status symbols, dynamic mode selector

### DIFF
--- a/src/Command/Components/PassPlan/PassPlan.css
+++ b/src/Command/Components/PassPlan/PassPlan.css
@@ -124,6 +124,10 @@ rux-tree-node[aria-level="2"]::part(node) {
   margin-right: var(--spacing-2);
 }
 
+.pass-plan_status-symbol {
+  padding-inline-end: var(--spacing-4);
+}
+
 /* Pre-Pass Complete Styles */
 
 .pass_pre-pass-complete-wrapper {

--- a/src/Command/Components/PassPlan/PassPlan.tsx
+++ b/src/Command/Components/PassPlan/PassPlan.tsx
@@ -8,6 +8,8 @@ import PassList from "./PassList/PassList";
 import { useAppContext, ContextType } from "provider/useAppContext";
 import PrePassComplete from "./PrePassComplete/PrePassComplete";
 import { Mnemonic } from "@astrouxds/mock-data";
+import { RuxSelectCustomEvent } from "@astrouxds/astro-web-components";
+import { addToast } from "utils";
 
 const PassPlan = () => {
   const [command, setCommand] = useState<object>({});
@@ -26,6 +28,13 @@ const PassPlan = () => {
     if (!commandListItem) return;
     setCommandList([...commandList, commandListItem.commandString]);
   };
+
+  const handlePassModeSelect = (e: RuxSelectCustomEvent<void>) => {
+    if (e.target.value === 'automatic') {
+      addToast('Feature not implemented.', false, 800);
+      e.target.value = "semi-auto"
+    }
+  }
 
   useEffect(() => {
     let interval: any;
@@ -55,9 +64,12 @@ const PassPlan = () => {
           className="pass-plan_header-select"
           size="small"
           label="Mode"
+          disabled={ pass !== "Pass" ? true : false }
+          value={ pass !== "Pass" ? "automatic" : "semi-auto" }
+          onRuxchange={(e) => handlePassModeSelect(e)}
         >
-          <RuxOption label="Semi-Auto" value="" />
-          <RuxOption label="Automatic" value="" />
+          <RuxOption label="Automatic" value="automatic" />
+          <RuxOption label="Semi-Auto" value="semi-auto" />
         </RuxSelect>
       </div>
       <div className={`pass-plan_banner ${pass}`}>

--- a/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
+++ b/src/Command/Components/PassPlan/PrePassList/PrePassList.tsx
@@ -1,9 +1,4 @@
-import {
-  RuxCheckbox,
-  RuxProgress,
-  RuxTree,
-  RuxTreeNode,
-} from "@astrouxds/react";
+import { RuxProgress, RuxStatus, RuxTree, RuxTreeNode } from "@astrouxds/react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 type PropTypes = {
@@ -32,9 +27,6 @@ const PrePassList = ({ setPass }: PropTypes) => {
     const ruxProgress: HTMLRuxProgressElement[] = Array.from(
       document.querySelectorAll("rux-progress.pre-pass_progress")
     )!;
-    const ruxCheckbox: HTMLRuxCheckboxElement[] = Array.from(
-      document.querySelectorAll("rux-checkbox.pass-plan_checkbox")
-    )!;
 
     // if the current list item is the length of the state function array, set the pass from 'pre-pass' into 'pass'
     if (currentListItem === stateFunctionArray.length) {
@@ -58,7 +50,6 @@ const PrePassList = ({ setPass }: PropTypes) => {
     //for each list item, wait the allotted time and then set the checkbox to checked and the text to complete.
     setTimeout(() => {
       stateFunctionArray[currentListItem]("CONNECTED");
-      ruxCheckbox[currentListItem].checked = true;
 
       // if on the last item, wait a little longer to make sure the user can see the state change to 'complete' before swapping to 'pass'
       if (currentListItem === stateFunctionArray.length - 1) {
@@ -79,7 +70,11 @@ const PrePassList = ({ setPass }: PropTypes) => {
           1
         </div>
         <div className="pass-plan_tree-content-wrapper">
-          <RuxCheckbox className="pass-plan_checkbox" />
+          {aimState === "PENDING" ? (
+            <RuxStatus className="pass-plan_status-symbol" status="standby" />
+          ) : (
+            <RuxStatus className="pass-plan_status-symbol" status="normal" />
+          )}
           AIM = {aimState}
         </div>
         <RuxProgress
@@ -93,7 +88,11 @@ const PrePassList = ({ setPass }: PropTypes) => {
           2
         </div>
         <div className="pass-plan_tree-content-wrapper">
-          <RuxCheckbox className="pass-plan_checkbox" />
+          {sarmState === "PENDING" ? (
+            <RuxStatus className="pass-plan_status-symbol" status="standby" />
+          ) : (
+            <RuxStatus className="pass-plan_status-symbol" status="normal" />
+          )}
           SARM = {sarmState}
         </div>
         <RuxProgress
@@ -107,7 +106,11 @@ const PrePassList = ({ setPass }: PropTypes) => {
           3
         </div>
         <div className="pass-plan_tree-content-wrapper">
-          <RuxCheckbox className="pass-plan_checkbox" />
+          {lockState === "PENDING" ? (
+            <RuxStatus className="pass-plan_status-symbol" status="standby" />
+          ) : (
+            <RuxStatus className="pass-plan_status-symbol" status="normal" />
+          )}
           LOCK = {lockState}
         </div>
         <RuxProgress
@@ -121,7 +124,11 @@ const PrePassList = ({ setPass }: PropTypes) => {
           4
         </div>
         <div className="pass-plan_tree-content-wrapper">
-          <RuxCheckbox className="pass-plan_checkbox" />
+          {aosState === "PENDING" ? (
+            <RuxStatus className="pass-plan_status-symbol" status="standby" />
+          ) : (
+            <RuxStatus className="pass-plan_status-symbol" status="normal" />
+          )}
           AOS = {aosState}
         </div>
         <RuxProgress
@@ -135,7 +142,11 @@ const PrePassList = ({ setPass }: PropTypes) => {
           5
         </div>
         <div className="pass-plan_tree-content-wrapper">
-          <RuxCheckbox className="pass-plan_checkbox" />
+          {vccState === "PENDING" ? (
+            <RuxStatus className="pass-plan_status-symbol" status="standby" />
+          ) : (
+            <RuxStatus className="pass-plan_status-symbol" status="normal" />
+          )}
           VCC = {vccState}
         </div>
         <RuxProgress
@@ -149,7 +160,11 @@ const PrePassList = ({ setPass }: PropTypes) => {
           6
         </div>
         <div className="pass-plan_tree-content-wrapper">
-          <RuxCheckbox className="pass-plan_checkbox" />
+          {passPlanState === "PENDING" ? (
+            <RuxStatus className="pass-plan_status-symbol" status="standby" />
+          ) : (
+            <RuxStatus className="pass-plan_status-symbol" status="normal" />
+          )}
           PASS PLAN = {passPlanState}
         </div>
         <RuxProgress


### PR DESCRIPTION
This PR makes the following changes to the Pass Plan:

- Swaps out the checkboxes for status symbols in the pre-pass phase: standby to start, then normal when the progress bar completes.
- Changes the mode select menu at the top to be automatic for pre-pass and pre-pass complete (I also decided to make it disabled during this phase), then changing to semi auto on pass phase with a function that triggers a toast that indicates that the feature is not implemented if the user tries to swap from semi-auto to auto, and then swaps back to semi-auto.

[JIRA Ticket](https://rocketcom.atlassian.net/browse/DEMO-241)